### PR TITLE
gralloc: Fix Compilation errors

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -3,7 +3,7 @@ display_top := $(call my-dir)
 
 #Common C flags
 common_flags := -Wno-missing-field-initializers
-common_flags += -Wconversion -Wall -Werror
+common_flags += -Wconversion -Wall -Werror -Wno-sign-conversion
 common_flags += -DUSE_GRALLOC1
 ifeq ($(TARGET_IS_HEADLESS), true)
     common_flags += -DTARGET_HEADLESS


### PR DESCRIPTION
Include -Wno-sign-conversion flag to avoid sign conversion warning.

Change-Id: I576ec57856ac1cab25ca657dcadbfbfa1dddf33c